### PR TITLE
Add ZFS set for extra metadata

### DIFF
--- a/lib/btrfs_store.ml
+++ b/lib/btrfs_store.ml
@@ -132,7 +132,7 @@ let create root =
   purge (root / "cache-tmp") >>= fun () ->
   Lwt.return { root; caches = Hashtbl.create 10; next = 0 }
 
-let build t ?base ~id fn =
+let build t ?base ~id ~meta:_ fn =
   let result = Path.result t id in
   let result_tmp = Path.result_tmp t id in
   assert (not (Sys.file_exists result));        (* Builder should have checked first *)

--- a/lib/db_store.mli
+++ b/lib/db_store.mli
@@ -6,6 +6,7 @@ module Make (Raw : S.STORE) : sig
     t -> ?base:S.id ->
     id:S.id ->
     log:S.logger ->
+    meta:(string * string) list ->
     (cancelled:unit Lwt.t -> log:Build_log.t -> string -> (unit, [`Cancelled | `Msg of string]) Lwt_result.t) ->
     (S.id, [> `Cancelled | `Failed of (S.id * string)]) Lwt_result.t
   (** [build t ~id ~log fn] ensures that [id] is cached, using [fn ~cancelled ~log dir] to build it if not.

--- a/lib/docker_store.ml
+++ b/lib/docker_store.ml
@@ -106,7 +106,7 @@ let create root =
   let* () = purge () in
   Lwt.return t
 
-let build t ?base ~id (fn:(string -> (unit, 'e) Lwt_result.t)) : (unit, 'e) Lwt_result.t =
+let build t ?base ~id ~meta:_ (fn:(string -> (unit, 'e) Lwt_result.t)) : (unit, 'e) Lwt_result.t =
   match base with
   | None ->
     Lwt.catch

--- a/lib/rsync_store.ml
+++ b/lib/rsync_store.ml
@@ -89,7 +89,7 @@ let create ~path ?(mode = Copy) () =
   Lwt_list.iter_s Rsync.create (Path.dirs path) >|= fun () ->
   { path; mode; caches = Hashtbl.create 10; next = 0 }
 
-let build t ?base ~id fn =
+let build t ?base ~id ~meta:_ fn =
   Log.debug (fun f -> f "rsync: build %S" id);
   let result = Path.result t id in
   let result_tmp = Path.result_tmp t id in

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -22,6 +22,7 @@ module type STORE = sig
   val build :
     t -> ?base:id ->
     id:id ->
+    meta:(string * string) list ->
     (string -> (unit, 'e) Lwt_result.t) ->
     (unit, 'e) Lwt_result.t
   (** [build t ~id fn] runs [fn tmpdir] to add a new item to the store under
@@ -32,7 +33,8 @@ module type STORE = sig
       The builder will not request concurrent builds for the same [id] (it
       will handle that itself). It will also not ask for a build that already
       exists (i.e. for which [result] returns a path).
-      @param base Initialise [tmpdir] as a clone of [base]. *)
+      @param base Initialise [tmpdir] as a clone of [base].
+      @param meta Metadata that can be stored as a key-value list with the result. *)
 
   val delete : t -> id -> unit Lwt.t
   (** [delete t id] removes [id] from the store, if present. *)

--- a/lib/xfs_store.ml
+++ b/lib/xfs_store.ml
@@ -56,7 +56,7 @@ let create ~path =
   Lwt_list.iter_s Xfs.create (Path.dirs path) >|= fun () ->
   { path; caches = Hashtbl.create 10; next = 0 }
 
-let build t ?base ~id fn =
+let build t ?base ~id ~meta:_ fn =
   Log.debug (fun f -> f "xfs: build %S" id);
   let result = Path.result t id in
   let result_tmp = Path.result_tmp t id in


### PR DESCRIPTION
This commit adds a `meta` argument to builds allowing additional key-value information to be associated to builds. This only works on the ZFS backend for now, other stores quietly ignore the meta argument and work as they did before.