### PR TITLE
Raise restriction on shared memory in container.

### DIFF
--- a/lib/sandbox.runc.ml
+++ b/lib/sandbox.runc.ml
@@ -207,7 +207,7 @@ module Json_config = struct
             "noexec";
             "nodev";
             "mode=1777";
-            "size=65536k";
+            "size=65536m";
           ] ::
         mount "/dev/mqueue"
           ~ty:"mqueue"


### PR DESCRIPTION
64MB, which is the default, is too small to be useful in a geospatial context. This changes it to 64GB, which might still be too small, but is a start, and lets me do some LIFE calculations that I couldn't before.